### PR TITLE
new parameter hardwaretuning includes max and min frequency for reserved cpus

### DIFF
--- a/cmd/performance-profile-creator/cmd/root.go
+++ b/cmd/performance-profile-creator/cmd/root.go
@@ -99,6 +99,8 @@ type ProfileData struct {
 	realtimeHint              *bool
 	highPowerConsumptionHint  *bool
 	perPodPowerManagementHint *bool
+	reservedCpuMinFreq        int
+	reservedCpuMaxFreq        int
 }
 
 // ClusterData collects the cluster wide information, each mcp points to a list of ghw node handlers
@@ -193,6 +195,7 @@ func NewRootCommand() *cobra.Command {
 	root.PersistentFlags().StringVar(&pcArgs.TMPolicy, "topology-manager-policy", kubeletconfig.RestrictedTopologyManagerPolicy, fmt.Sprintf("Kubelet Topology Manager Policy of the performance profile to be created. [Valid values: %s, %s, %s]", kubeletconfig.SingleNumaNodeTopologyManagerPolicy, kubeletconfig.BestEffortTopologyManagerPolicy, kubeletconfig.RestrictedTopologyManagerPolicy))
 	root.PersistentFlags().StringVar(&pcArgs.Info, "info", infoModeLog, fmt.Sprintf("Show cluster information; requires --must-gather-dir-path, ignore the other arguments. [Valid values: %s]", strings.Join(validInfoModes, ", ")))
 	root.PersistentFlags().BoolVar(pcArgs.PerPodPowerManagement, "per-pod-power-management", false, "Enable Per Pod Power Management")
+	root.PersistentFlags().BoolVar(&pcArgs.BoostFrequency, "boost-frequency", false, "Enable frequency tuning for reserved cpus")
 
 	return root
 }
@@ -400,6 +403,11 @@ func getDataFromFlags(cmd *cobra.Command) (ProfileCreatorArgs, error) {
 		return creatorArgs, fmt.Errorf("failed to parse disable-ht flag: %v", err)
 	}
 
+	boostFrequency, err := strconv.ParseBool(cmd.Flag("boost-frequency").Value.String())
+	if err != nil {
+		return creatorArgs, fmt.Errorf("failed to parse boost-frequency flag: %v", err)
+	}
+
 	creatorArgs = ProfileCreatorArgs{
 		MustGatherDirPath:           mustGatherDirPath,
 		ProfileName:                 profileName,
@@ -411,6 +419,7 @@ func getDataFromFlags(cmd *cobra.Command) (ProfileCreatorArgs, error) {
 		RTKernel:                    rtKernelEnabled,
 		PowerConsumptionMode:        powerConsumptionMode,
 		DisableHT:                   htDisabled,
+		BoostFrequency:              boostFrequency,
 	}
 
 	if cmd.Flag("user-level-networking").Changed {
@@ -485,6 +494,7 @@ func getProfileData(args ProfileCreatorArgs, cluster ClusterData) (*ProfileData,
 	}
 	log.Infof("%d reserved CPUs allocated: %v ", reservedCPUs.Size(), reservedCPUs.String())
 	log.Infof("%d isolated CPUs allocated: %v", isolatedCPUs.Size(), isolatedCPUs.String())
+
 	kernelArgs := profilecreator.GetAdditionalKernelArgs(args.DisableHT)
 	profileData := &ProfileData{
 		reservedCPUs:              reservedCPUs.String(),
@@ -499,6 +509,15 @@ func getProfileData(args ProfileCreatorArgs, cluster ClusterData) (*ProfileData,
 		userLevelNetworking:       args.UserLevelNetworking,
 		disableHT:                 args.DisableHT,
 		perPodPowerManagementHint: args.PerPodPowerManagement,
+	}
+
+	// test: set frequency value
+	if args.BoostFrequency {
+		profileData.reservedCpuMaxFreq, profileData.reservedCpuMinFreq, err = profilecreator.CalculateFrequency(args.MustGatherDirPath, profileData.reservedCPUs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compute the maximum and minimum frequencies for reserved CPUs: %v", err)
+		}
+		log.Infof("reserved CPUs max frequency:%v, min frequency:%v", profileData.reservedCpuMaxFreq, profileData.reservedCpuMinFreq)
 	}
 
 	// setting workload hints
@@ -558,6 +577,8 @@ type ProfileCreatorArgs struct {
 	TMPolicy                    string `json:"topology-manager-policy"`
 	Info                        string `json:"info"`
 	PerPodPowerManagement       *bool  `json:"per-pod-power-management,omitempty"`
+	//test
+	BoostFrequency bool `json:"boost-frequency,omitempty"`
 }
 
 func createProfile(profileData ProfileData) error {
@@ -593,7 +614,14 @@ func createProfile(profileData ProfileData) error {
 		offlined := performancev2.CPUSet(profileData.offlinedCPUs)
 		profile.Spec.CPU.Offlined = &offlined
 	}
-
+	if profileData.reservedCpuMaxFreq > 0 && profileData.reservedCpuMinFreq > 0 {
+		minFreq := performancev2.CPUfrequency(profileData.reservedCpuMinFreq)
+		maxFreq := performancev2.CPUfrequency(profileData.reservedCpuMaxFreq)
+		profile.Spec.HardwareTuning = &performancev2.HardwareTuning{
+			ReservedCpuMinFreq: &minFreq,
+			ReservedCpuMaxFreq: &maxFreq,
+		}
+	}
 	if len(profileData.additionalKernelArgs) > 0 {
 		profile.Spec.AdditionalKernelArgs = profileData.additionalKernelArgs
 	}

--- a/examples/performanceprofile/crd/bases/performance.openshift.io_performanceprofiles.yaml
+++ b/examples/performanceprofile/crd/bases/performance.openshift.io_performanceprofiles.yaml
@@ -86,6 +86,17 @@ spec:
                   per pod CPUs when using irq-load-balancing.crio.io/cpu-quota.crio.io
                   annotations. Defaults to "false"
                 type: boolean
+              hardwareTuning:
+                description: HardwareTuning
+                properties:
+                  reservedCpuMinFreq: 
+                    description: ReservedCpuMinFreq defines the maximum cpu frequency for reserved CPUs.
+                    format: int32
+                    type: string
+                  reservedCpuMaxFreq:
+                    description: ReservedCpuMaxFreq defines the maximum cpu frequency for reserved CPUs.
+                    format: int32
+                    type: integer
               hugepages:
                 description: HugePages defines a set of huge pages related parameters.
                   It is possible to set huge pages with multiple size values at the

--- a/pkg/apis/performanceprofile/v1/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v1/performanceprofile_types.go
@@ -30,6 +30,9 @@ const PerformanceProfilePauseAnnotation = "performance.openshift.io/pause-reconc
 type PerformanceProfileSpec struct {
 	// CPU defines a set of CPU related parameters.
 	CPU *CPU `json:"cpu"`
+	// HardwareTuning defines maximum and minuimum cpu frequencies for reserved cpus
+	// +optional
+	HardwareTuning *HardwareTuning `json:"hardwareTuning,omitempty"`
 	// HugePages defines a set of huge pages related parameters.
 	// It is possible to set huge pages with multiple size values at the same time.
 	// For example, hugepages can be set with 1G and 2M, both values will be set on the node by the performance-addon-operator.
@@ -78,6 +81,7 @@ type PerformanceProfileSpec struct {
 
 // CPUSet defines the set of CPUs(0-3,8-11).
 type CPUSet string
+type CPUfrequency int
 
 // CPU defines a set of CPU related features.
 type CPU struct {
@@ -103,6 +107,16 @@ type CPU struct {
 	// +optional
 	Offlined *CPUSet `json:"offlined,omitempty"`
 }
+
+// // HardwareTuning defines a set of CPU frequency related features.
+type HardwareTuning struct {
+	// ReservedCpuMinFreq defines a minimum frequency to be set across reserved cpus
+	ReservedCpuMinFreq *CPUfrequency `json:"reservedCpuMinFreq,omitempty"`
+	// ReservedCpuMaxFreq defines a maximum frequency to be set across reserved cpus
+	ReservedCpuMaxFreq *CPUfrequency `json:"reservedCpuMaxFreq,omitempty"`
+}
+
+//
 
 // HugePageSize defines size of huge pages, can be 2M or 1G.
 type HugePageSize string

--- a/pkg/apis/performanceprofile/v2/performanceprofile_conversion.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_conversion.go
@@ -33,6 +33,18 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 		}
 	}
 
+	if curr.Spec.HardwareTuning != nil {
+		dst.Spec.HardwareTuning = new(v1.HardwareTuning)
+		if curr.Spec.HardwareTuning.ReservedCpuMaxFreq != nil {
+			maxCpuFrequency := v1.CPUfrequency(*curr.Spec.HardwareTuning.ReservedCpuMaxFreq)
+			dst.Spec.HardwareTuning.ReservedCpuMaxFreq = &maxCpuFrequency
+		}
+		if curr.Spec.HardwareTuning.ReservedCpuMinFreq != nil {
+			minCpuFrequency := v1.CPUfrequency(*curr.Spec.HardwareTuning.ReservedCpuMaxFreq)
+			dst.Spec.HardwareTuning.ReservedCpuMinFreq = &minCpuFrequency
+		}
+	}
+
 	if curr.Spec.HugePages != nil {
 		dst.Spec.HugePages = new(v1.HugePages)
 

--- a/pkg/apis/performanceprofile/v2/performanceprofile_types.go
+++ b/pkg/apis/performanceprofile/v2/performanceprofile_types.go
@@ -38,6 +38,9 @@ const PerformanceProfileEnableRpsAnnotation = "performance.openshift.io/enable-r
 type PerformanceProfileSpec struct {
 	// CPU defines a set of CPU related parameters.
 	CPU *CPU `json:"cpu"`
+	// HardwareTuning defines maximum and minuimum cpu frequencies for reserved cpus
+	// +optional
+	HardwareTuning *HardwareTuning `json:"hardwareTuning,omitempty"`
 	// HugePages defines a set of huge pages related parameters.
 	// It is possible to set huge pages with multiple size values at the same time.
 	// For example, hugepages can be set with 1G and 2M, both values will be set on the node by the Performance Profile Controller.
@@ -86,6 +89,7 @@ type PerformanceProfileSpec struct {
 
 // CPUSet defines the set of CPUs(0-3,8-11).
 type CPUSet string
+type CPUfrequency int
 
 // CPU defines a set of CPU related features.
 type CPU struct {
@@ -110,6 +114,14 @@ type CPU struct {
 	// Offline defines a set of CPUs that will be unused and set offline
 	// +optional
 	Offlined *CPUSet `json:"offlined,omitempty"`
+}
+
+// // HardwareTuning defines a set of CPU frequency related features.
+type HardwareTuning struct {
+	// ReservedCpuMinFreq defines a minimum frequency to be set across reserved cpus
+	ReservedCpuMinFreq *CPUfrequency `json:"reservedCpuMinFreq,omitempty"`
+	// ReservedCpuMaxFreq defines a maximum frequency to be set across reserved cpus
+	ReservedCpuMaxFreq *CPUfrequency `json:"reservedCpuMaxFreq,omitempty"`
 }
 
 // HugePageSize defines size of huge pages, can be 2M or 1G.


### PR DESCRIPTION
## What?
Configuring CPU frequency for reserved and isolated cpus through PerformanceProfile.

## Why?

- For FlexRAN (and FlexRAN-like applications), the hardware vendors require that the default cpu frequency be set to a specific frequency for running workloads which is actually lower than the default running frequency.
- Users constantly ask for reducing the platform core footprint. By setting higher frequencies for reserved cpus can  translates the effort into reducing the number of cpu cores reserved for running Openshift components.

## Additional resources:
- EPIC link: [Reserved Core Frequency Tuning](https://issues.redhat.com/browse/CNF-9112)
- [Design discussion](https://docs.google.com/document/d/1KW3Wy14L2w3hAF4DF6LIwhT7jdprlutTPPuGIgWf1Xw/edit)

 ## Characteristics
 - CPU frequency setting is optional
 - Requires **intel_pstate to be active**
 - This low level parameters should only be used based on the vendors recommendation on frequencies.
 - Feature is hardware agnostic, but must follow frequency guideline depending on hw generation.
 
 ## How?
By introducing a `hardwareTuning` parameter in the spec of PerformanceProfile. The onus is on user to provide correct frequencies.

```
hardwareTuning:
  isolatedCpuFreq: 2500000
  reservedCpuFreq: 2800000
```
It will update the `assets/performanceprofile/tuned/openshift-node-performance` and cpu plugin will apply the frequencies using sysfs directive
## Changes
- Extended CRD definition
- Modified static openshift-node-performance profile
- intel_pstate=active is changed as default
- When realTime workloadHints is set to true, previously it would disable intel_pstate and would inactive cpufreq driver. With this proposal, `intel_pstate=active` is set for `realTime=true`
- Extended performance profile creator by introducing a new flag i.e.; `--enable-hardware-tuning`. When passed, commented lines get added at the end with an example on how to set the frequency values. For example:
```
apiVersion: performance.openshift.io/v2
kind: PerformanceProfile
metadata:
  name: performance
spec:
  cpu:
    isolated: 4-15
    reserved: 0-3
    .......................
    .......................
  workloadHints:
    highPowerConsumption: false
    perPodPowerManagement: false
    realTime: true
#HardwareTuning is an advanced feature, and only intended to be used if 
#user is aware of the vendor recommendation on maximum cpu frequency.
#The structure must follow
#
# hardwareTuning:
#   isolatedCpuFreq: <Maximum frequency for applications running on isolated cpus>
#   reservedCpuFreq: <Maximum frequency for platform software running on reserved cpus>
```
## When it will not work?
- For RAN cases, we recommend below workloadHints:
```
    highPowerConsumption: false
    perPodPowerManagement: false
    realTime: true
```
if perPodPowerManagement is set to true, the default intel_pstate is set to passive. For this feature to take in effect, P-state needs to be active. Therefore, cpu frequencies will not be set if perPodPowerManagement is true
- Providing incorrect frequencies will not take in effect, and it is strongly recommended to follow hardware vendors guideline.

## Can it be done other ways?
Changing cpu frequencies can be done through the tuned performance-patch, using the sysfs plugin. This would look something like this (using 2.5 GHz as the default frequency and 2.8 GHz for reserved CPUs on a system with 64 CPUs and CPUS 0,1,32,33 reserved for the platform):
```
[sysfs]
/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq=2800000
/sys/devices/system/cpu/cpu1/cpufreq/scaling_max_freq=2800000
/sys/devices/system/cpu/cpu2/cpufreq/scaling_max_freq=2500000
/sys/devices/system/cpu/cpu3/cpufreq/scaling_max_freq=2500000
<...>
/sys/devices/system/cpu/cpu31/cpufreq/scaling_max_freq=2500000
/sys/devices/system/cpu/cpu32/cpufreq/scaling_max_freq=2800000
/sys/devices/system/cpu/cpu33/cpufreq/scaling_max_freq=2800000
/sys/devices/system/cpu/cpu34/cpufreq/scaling_max_freq=2500000
/sys/devices/system/cpu/cpu35/cpufreq/scaling_max_freq=2500000
<...>
/sys/devices/system/cpu/cpu63/cpufreq/scaling_max_freq=2500000
```
This requires 64 lines of configuration (one per logical CPU). The proposed approach reduces the complexity of this configuration, makes it lesser prone to mistake from users side.